### PR TITLE
Implemented 1.17, 1.16

### DIFF
--- a/src/main/java/core/Application.java
+++ b/src/main/java/core/Application.java
@@ -1,6 +1,8 @@
 package core;
 
+import core.information.ChangelogInformation;
 import core.information.PackageInformation;
+import core.information.VersionInformation;
 import database.services.GraphDBService;
 import org.neo4j.ogm.config.Configuration;
 import org.springframework.boot.SpringApplication;
@@ -15,7 +17,9 @@ import org.springframework.data.neo4j.repository.config.EnableNeo4jRepositories;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @SpringBootApplication
@@ -23,9 +27,13 @@ import java.util.stream.Collectors;
 @SpringBootConfiguration
 @ComponentScan(basePackages = "database.*")
 public class Application {
+    private static final String COMMIT_NA = "COMMIT_NA";
+
     public static void main(String[] args) throws IOException {
+        //Loading config
         Config.load(args);
 
+        //Analysing current version
         Path scanLocation = Config.getPath("project.uri", null);
         if (scanLocation == null) throw new IOException("project.uri is not properly defined in config.properties");
 
@@ -36,12 +44,34 @@ public class Application {
         Collection<PackageInformation> packages = extractor.analyseClasses(alg.getList().stream()
                 .map(File::getAbsolutePath).collect(Collectors.toList()));
 
-        DependencyListWriter.writeListToFile(packages, Config.get("report.destination", "report"), "test");
+        //Writing Analyse to a File
+        DependencyListWriter.writeListToFile(packages, Config.get("report.destination", "report"), "report");
 
+        //Starting Database Service
         ConfigurableApplicationContext ctx = SpringApplication.run(Application.class, args);
         GraphDBService graphDBService = ctx.getBean(GraphDBService.class);
-        graphDBService.saveAllNodes(packages);
-        graphDBService.getPackageRepository().findAll();
+
+        //Getting previous Commit
+        VersionInformation previous;
+        String previousCommitName = Config.get("project.commit.previous", COMMIT_NA);
+
+        if (previousCommitName.equals(COMMIT_NA)) {
+            previous = new VersionInformation(new ArrayList<>(), "init");
+        } else {
+            previous = graphDBService.getVersionRepository().findVersionInformationByVersionName(previousCommitName);
+            if (previous == null)
+                throw new NoSuchElementException("Commit " + previousCommitName + " does not exist in the database");
+        }
+
+        VersionInformation current = new VersionInformation(packages, Config.get("project.commit", COMMIT_NA), previous);
+
+        //Analyse differences between current and previous Commit
+        DiffExtractor diffExtractor = new DiffExtractor(previous.getPackageInformations(), packages);
+
+        //Save the Analysis in the Database
+        graphDBService.saveVersion(current);
+        graphDBService.saveChangelog(new ChangelogInformation(diffExtractor.getChangelist(), previous, current));
+
         ctx.close();
     }
 

--- a/src/main/java/core/information/ChangelogDependencyInformation.java
+++ b/src/main/java/core/information/ChangelogDependencyInformation.java
@@ -4,17 +4,17 @@ import java.util.Objects;
 import java.util.SortedSet;
 
 /**
- * * BehaviorInformation with additional change meta (whether it was added or deleted).
+ * * MethodInformation with additional change meta (whether it was added or deleted).
  */
 public class ChangelogDependencyInformation extends MethodInformation {
 
     private ChangeStatus changeStatus;
 
     /**
-     * Instantiates a new Behavior information.
+     * Instantiates a new ChangelogDependencyInformation.
      *
-     * @param methodInformation the behavior to copy from
-     * @param changeStatus        whenever this behavior was deleted or added
+     * @param methodInformation the method to copy from
+     * @param changeStatus      whenever this method was deleted or added
      */
     public ChangelogDependencyInformation(MethodInformation methodInformation, ChangeStatus changeStatus) {
         super(methodInformation.getName(), methodInformation.getPackageDependencies(), methodInformation.getClassDependencies(), methodInformation.getMethodDependencies(), methodInformation.isConstructor());
@@ -22,11 +22,11 @@ public class ChangelogDependencyInformation extends MethodInformation {
     }
 
     /**
-     * Instantiates a new Behavior information.
+     * Instantiates a new ChangelogDependencyInformation.
      *
-     * @param name          the name of the behavior
-     * @param isConstructor true if this behavior is a constructor
-     * @param changeStatus  whenever this behavior was deleted or added
+     * @param name          the name of the method
+     * @param isConstructor true if this method is a constructor
+     * @param changeStatus  whenever this method was deleted or added
      */
     public ChangelogDependencyInformation(String name, boolean isConstructor, ChangeStatus changeStatus) {
         super(name, isConstructor);
@@ -34,14 +34,14 @@ public class ChangelogDependencyInformation extends MethodInformation {
     }
 
     /**
-     * Instantiates a new Behavior information.
+     * Instantiates a new ChangelogDependencyInformation.
      *
-     * @param name               the name of the behavior
+     * @param name                the name of the method
      * @param packageDependencies the referenced packages
-     * @param classDependencies  the referenced classes
-     * @param methodDependencies the referenced behavior
-     * @param isConstructor      true if behavior is constructor
-     * @param changeStatus       whenever this behavior was deleted or added
+     * @param classDependencies   the referenced classes
+     * @param methodDependencies  the referenced method
+     * @param isConstructor       true if method is constructor
+     * @param changeStatus        whenever this method was deleted or added
      */
     public ChangelogDependencyInformation(String name, SortedSet<PackageInformation> packageDependencies, SortedSet<ClassInformation> classDependencies, SortedSet<MethodInformation> methodDependencies, boolean isConstructor, ChangeStatus changeStatus) {
         super(name, packageDependencies, classDependencies, methodDependencies, isConstructor);

--- a/src/main/java/core/information/ChangelogDependencyInformation.java
+++ b/src/main/java/core/information/ChangelogDependencyInformation.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import java.util.SortedSet;
 
 /**
- * * MethodInformation with additional change meta (whether it was added or deleted).
+ * MethodInformation with additional change meta (whether it was added or deleted).
  */
 public class ChangelogDependencyInformation extends MethodInformation {
 

--- a/src/main/java/core/information/ChangelogInformation.java
+++ b/src/main/java/core/information/ChangelogInformation.java
@@ -1,0 +1,74 @@
+package core.information;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+import org.springframework.context.annotation.Lazy;
+
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * ChangelogInformation is a Class for managing the position of a changelog between two commits/versions.
+ */
+@NodeEntity
+public class ChangelogInformation {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Relationship(type = "CHANGELOG")
+    private SortedSet<PackageInformation> changelog;
+
+    @Lazy
+    @Relationship(type = "BEFORE")
+    private VersionInformation before;
+
+    @Lazy
+    @Relationship(type = "AFTER")
+    private VersionInformation after;
+
+
+    /**
+     * Instantiates a new Changelog information.
+     *
+     * @param changelog the changelog
+     * @param before    the before
+     * @param after     the after
+     */
+    public ChangelogInformation(Collection<PackageInformation> changelog,
+                                VersionInformation before, VersionInformation after) {
+        this.changelog = new TreeSet<>(changelog);
+        this.before = before;
+        this.after = after;
+    }
+
+    /**
+     * Gets changelog.
+     *
+     * @return the changelog
+     */
+    public SortedSet<PackageInformation> getChangelog() {
+        return changelog;
+    }
+
+    /**
+     * Gets the Version before commit.
+     *
+     * @return the before
+     */
+    public VersionInformation getBefore() {
+        return before;
+    }
+
+    /**
+     * Gets the Version after commit.
+     *
+     * @return the after
+     */
+    public VersionInformation getAfter() {
+        return after;
+    }
+}

--- a/src/main/java/core/information/VersionInformation.java
+++ b/src/main/java/core/information/VersionInformation.java
@@ -1,0 +1,84 @@
+package core.information;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * VersionInformation is a class for Versions/Commits, which have been analysed.
+ */
+@NodeEntity
+public class VersionInformation {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String versionName;
+
+    @Relationship(type = "IS_VERSION_OF")
+    private SortedSet<PackageInformation> packageInformations;
+
+    @Relationship(type = "FOLLOWED")
+    private VersionInformation previousVersion = null;
+
+    /**
+     * Instantiates a new Version information without a previousVersion. Used primarily for the first Commit/Version.
+     *
+     * @param packageInformations the package informations
+     * @param versionName         the version/commit name
+     */
+    public VersionInformation(Collection<PackageInformation> packageInformations, String versionName) {
+        this.packageInformations = new TreeSet<>(packageInformations);
+        this.versionName = versionName;
+    }
+
+    /**
+     * Instantiates a new Version information.
+     *
+     * @param packageInformations the package informations
+     * @param versionName         the version/commit name
+     * @param previousVersion     the previous version
+     */
+    public VersionInformation(Collection<PackageInformation> packageInformations, String versionName, VersionInformation previousVersion) {
+        this.packageInformations = new TreeSet<>(packageInformations);
+        this.versionName = versionName;
+        this.previousVersion = previousVersion;
+    }
+
+    /**
+     * Is needed for Spring Data, should not be used otherwise.
+     */
+    private VersionInformation() {
+    }
+
+    /**
+     * Gets version name.
+     *
+     * @return the version name
+     */
+    public String getVersionName() {
+        return versionName;
+    }
+
+    /**
+     * Gets the analysed packageInformation Set.
+     *
+     * @return the package informations
+     */
+    public SortedSet<PackageInformation> getPackageInformations() {
+        return packageInformations;
+    }
+
+    /**
+     * Gets previous version.
+     *
+     * @return the previous version
+     */
+    public VersionInformation getPreviousVersion() {
+        return previousVersion;
+    }
+}

--- a/src/main/java/database/repositories/ChangeLogRepository.java
+++ b/src/main/java/database/repositories/ChangeLogRepository.java
@@ -1,0 +1,13 @@
+package database.repositories;
+
+import core.information.ChangelogInformation;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository to retrieve {@link ChangelogInformation} nodes that are stored in the Database.
+ */
+@Repository
+public interface ChangeLogRepository extends Neo4jRepository<ChangelogInformation, Long> {
+
+}

--- a/src/main/java/database/repositories/VersionRepository.java
+++ b/src/main/java/database/repositories/VersionRepository.java
@@ -1,0 +1,13 @@
+package database.repositories;
+
+import core.information.VersionInformation;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository to retrieve {@link VersionInformation} nodes that are stored in the Database.
+ */
+@Repository
+public interface VersionRepository extends Neo4jRepository<VersionInformation, Long> {
+    VersionInformation findVersionInformationByVersionName(String versionName);
+}

--- a/src/main/java/database/services/GraphDBService.java
+++ b/src/main/java/database/services/GraphDBService.java
@@ -1,9 +1,9 @@
 package database.services;
 
+import core.information.ChangelogInformation;
 import core.information.PackageInformation;
-import database.repositories.MethodRepository;
-import database.repositories.ClassRepository;
-import database.repositories.PackageRepository;
+import core.information.VersionInformation;
+import database.repositories.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,23 +17,30 @@ public class GraphDBService {
     private PackageRepository packageRepository;
     private ClassRepository classRepository;
     private MethodRepository methodRepository;
+    private VersionRepository versionRepository;
+    private ChangeLogRepository changeLogRepository;
 
     /**
      * Instantiates a new GraphDBService.
      *
-     * @param packageRepository  {@link PackageRepository}
-     * @param classRepository    {@link ClassRepository}
-     * @param methodRepository {@link MethodRepository}
+     * @param packageRepository   {@link PackageRepository}
+     * @param classRepository     {@link ClassRepository}
+     * @param methodRepository  {@link MethodRepository}
+     * @param versionRepository   the version repository
+     * @param changeLogRepository the change log repository
      */
     public GraphDBService(PackageRepository packageRepository, ClassRepository classRepository,
-                          MethodRepository methodRepository) {
+                          MethodRepository methodRepository, VersionRepository versionRepository,
+                          ChangeLogRepository changeLogRepository) {
         this.packageRepository = packageRepository;
         this.classRepository = classRepository;
         this.methodRepository = methodRepository;
+        this.versionRepository = versionRepository;
+        this.changeLogRepository = changeLogRepository;
     }
 
     /**
-     * Saves all Nodes in the Database.
+     * Saves all Nodes in the database.
      *
      * @param packages Output of DependencyExtractor
      */
@@ -48,17 +55,68 @@ public class GraphDBService {
         });
     }
 
+    /**
+     * Saves a changelog in the database.
+     *
+     * @param changelog the change log
+     */
+    @Transactional
+    public void saveChangelog(ChangelogInformation changelog) {
+        changeLogRepository.save(changelog);
+    }
+
+    /**
+     * Saves a version in the database.
+     *
+     * @param versionInformation the version information
+     */
+    @Transactional
+    public void saveVersion(VersionInformation versionInformation) {
+        versionRepository.save(versionInformation);
+    }
+
+    /**
+     * Gets package repository.
+     *
+     * @return the package repository
+     */
     public PackageRepository getPackageRepository() {
         return packageRepository;
     }
 
+    /**
+     * Gets class repository.
+     *
+     * @return the class repository
+     */
     public ClassRepository getClassRepository() {
         return classRepository;
     }
 
+    /**
+     * Gets behavior repository.
+     *
+     * @return the behavior repository
+     */
     public MethodRepository getMethodRepository() {
         return methodRepository;
     }
 
+    /**
+     * Gets version repository.
+     *
+     * @return the version repository
+     */
+    public VersionRepository getVersionRepository() {
+        return versionRepository;
+    }
 
+    /**
+     * Gets change log repository.
+     *
+     * @return the change log repository
+     */
+    public ChangeLogRepository getChangeLogRepository() {
+        return changeLogRepository;
+    }
 }

--- a/src/main/java/database/services/GraphDBService.java
+++ b/src/main/java/database/services/GraphDBService.java
@@ -94,9 +94,9 @@ public class GraphDBService {
     }
 
     /**
-     * Gets behavior repository.
+     * Gets method repository.
      *
-     * @return the behavior repository
+     * @return the method repository
      */
     public MethodRepository getMethodRepository() {
         return methodRepository;

--- a/src/test/java/database/services/GraphDBServiceTest.java
+++ b/src/test/java/database/services/GraphDBServiceTest.java
@@ -2,9 +2,8 @@ package database.services;
 
 import core.Application;
 import core.DependencyExtractor;
-import core.information.MethodInformation;
-import core.information.ClassInformation;
-import core.information.PackageInformation;
+import core.DiffExtractor;
+import core.information.*;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -21,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -79,5 +79,53 @@ public class GraphDBServiceTest {
         assertThat(testMethod).isEqualTo(graphDBService.getMethodRepository().findByName(testMethod.getName()));
 
         graphDBService.getPackageRepository().deleteAll(packages);
+    }
+
+    @Test
+    void saveChangelogTest() {
+        Collection<PackageInformation> changes = new DiffExtractor(packages, new ArrayList<>()).getChangelist();
+        ChangelogInformation changelogInformation = new ChangelogInformation(changes, null, null);
+        graphDBService.saveChangelog(changelogInformation);
+
+        changelogInformation = graphDBService.getChangeLogRepository().findAll().iterator().next();
+        assertThat(changelogInformation).isNotNull();
+        assertThat(changelogInformation.getChangelog()).isNotEmpty();
+
+        PackageInformation testPackage = graphDBService.getPackageRepository().findByPackageName("testclasses");
+        assertThat(testPackage).isNotNull();
+        assertThat(testPackage).isInstanceOf(PackageInformation.class);
+
+        ClassInformation testClass = testPackage.getClassInformations().first();
+        assertThat(testClass).isEqualTo(graphDBService.getClassRepository().findByClassName(testClass.getClassName()));
+
+        MethodInformation testMethod = testClass.getMethodInformations().first();
+        assertThat(testMethod).isEqualTo(graphDBService.getMethodRepository().findByName(testMethod.getName()));
+
+        assertThat(testMethod.getMethodDependencies()).hasOnlyElementsOfType(ChangelogDependencyInformation.class);
+
+        graphDBService.getChangeLogRepository().delete(changelogInformation);
+    }
+
+    @Test
+    void saveVersionTest() {
+        graphDBService.saveVersion(new VersionInformation(packages, "test"));
+        VersionInformation version = graphDBService.getVersionRepository().findVersionInformationByVersionName("test");
+        assertThat(version).isNotNull();
+
+        PackageInformation testPackage = version.getPackageInformations().stream()
+                .filter(packageInformation -> packageInformation.getPackageName().equals("testclasses")).findFirst().orElse(null);
+        assertThat(testPackage).isNotNull();
+        assertThat(testPackage).isInstanceOf(PackageInformation.class);
+        assertThat(testPackage).isEqualTo(packages.stream()
+                .filter(packageInformation -> packageInformation.getPackageName().equals("testclasses"))
+                .findFirst().orElse(null));
+
+        ClassInformation testClass = testPackage.getClassInformations().first();
+        assertThat(testClass).isEqualTo(graphDBService.getClassRepository().findByClassName(testClass.getClassName()));
+
+        MethodInformation testMethod = testClass.getMethodInformations().first();
+        assertThat(testMethod).isEqualTo(graphDBService.getMethodRepository().findByName(testMethod.getName()));
+
+        graphDBService.getVersionRepository().delete(version);
     }
 }


### PR DESCRIPTION
Added ChangelogInformation as a Dataclass to store the changelog.
Added VersionInformation to store the current analyse result.
GraphDBService can now save Version and Changelog.
Application now saves Version and Changelog.
Changed variable names so that they are more comprehensible.